### PR TITLE
fix: clarify dataset split handling as per issue #379 in devkit

### DIFF
--- a/nuplan/planning/script/config/common/scenario_builder/nuplan.yaml
+++ b/nuplan/planning/script/config/common/scenario_builder/nuplan.yaml
@@ -1,7 +1,7 @@
 _target_: nuplan.planning.scenario_builder.nuplan_db.nuplan_scenario_builder.NuPlanScenarioBuilder
 _convert_: 'all'
 
-data_root: ${oc.env:NUPLAN_DATA_ROOT}/nuplan-v1.1/trainval
+data_root: ${oc.env:NUPLAN_DATA_ROOT}/nuplan-v1.1/splits/trainval
 map_root: ${oc.env:NUPLAN_MAPS_ROOT}
 sensor_root: ${oc.env:NUPLAN_DATA_ROOT}/nuplan-v1.1/sensor_blobs
 


### PR DESCRIPTION
Adjusted documentation and config behavior to resolve ambiguity in trainval/test split, as discussed in https://github.com/motional/nuplan-devkit/issues/379#issuecomment-2472534146.